### PR TITLE
Update pharmrep.dtx

### DIFF
--- a/pharmrep.dtx
+++ b/pharmrep.dtx
@@ -206,7 +206,7 @@ This work consists of all files listed in manifest.txt.
 % \section{Dealing with Typical Problems by using PharmRep}
 % One typical problem that may occur when using Latex respectively the PharmRep package may occur, 
 % when the PDF that was successfully compiled remains opened when further editing the tex-file. With the 
-% PDF opened, the compilation process cannot be performed and the following error message apprears:
+% PDF opened, the compilation process cannot be performed and the following error message appears:
 % MedRepStyle<xx>.tex: Fehler; Zeile 30: I can't write on file 'MedRepManual23.pdf' ..
 % Once the PDF is closed, compilation can be performed without any problems.
 %


### PR DESCRIPTION
GitHub-User-Test by BJ: typo in line 209 correct (appears instead of app**r**ears)
